### PR TITLE
Add SSH restart to Ubuntu tasks

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,3 +7,10 @@
   service:
     name=sssd
     state=restarted
+
+- name: restart ssh
+  tags: sssd
+  become: true
+  service:
+    name=ssh
+    state=restarted

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -12,7 +12,9 @@
     - ubuntu
     - sssd
   become: true
-  notify: restart sssd
+  notify: 
+    - restart sssd
+    - restart ssh
   lineinfile:
     dest=/etc/sssd/sssd.conf
     regexp='^services.*'


### PR DESCRIPTION
The SSH service on the client machine must be restarted in order for the SSSD changes to take effect.
