### PR TITLE
Improvements

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@
 freeipaclient_force_join: false
 freeipaclient_enable_ntp: true
 freeipaclient_all_ip_addresses: true
+freeipaclient_enable_dns_updates: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
     - freeipaclient
   become: true
   with_items: "{{ packages }}"
-  action: "{{ ansible_pkg_mgr }} state=installed name={{ item }}"
+  action: "{{ ansible_pkg_mgr }} state=latest name={{ item }}"
 
 - name: Check if host is enrolled
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,5 +76,5 @@
   tags:
     - ubuntu
     - freeipaclient
-  when: ansible_distribution_release == 'trusty'
+  when: ansible_os_family == 'Debian'
   include: ubuntu.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,7 +39,7 @@
     - packagemanagement
     - freeipaclient
   become: true
-  with_items: packages
+  with_items: "{{ packages }}"
   action: "{{ ansible_pkg_mgr }} state=installed name={{ item }}"
 
 - name: Check if host is enrolled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,7 +66,7 @@
           --password={{ freeipaclient_enroll_pass }}
           --ssh-trust-dns
           --mkhomedir
-          --enable-dns-updates
+          {{ '--enable-dns-updates' if freeipaclient_enable_dns_updates else ''}}
           --unattended
           {{ '--all-ip-addresses' if freeipaclient_all_ip_addresses else ''}}
           {{ '--no-ntp' if not freeipaclient_enable_ntp else ''}}

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -2,3 +2,4 @@ freeipaclient_install_command: '/sbin/ipa-client-install'
 packages:
  - ipa-client
  - dbus-python
+ - nscd

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -2,3 +2,4 @@ freeipaclient_install_command: '/sbin/ipa-client-install'
 ansible_pkg_mgr: 'dnf'
 packages:
  - freeipa-client
+ - nscd

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -2,3 +2,4 @@ freeipaclient_install_command: '/usr/sbin/ipa-client-install'
 packages:
  - freeipa-client
  - dnsutils
+ - nscd

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,5 +2,6 @@
 # vars file for ansible-freeipa-client
 freeipaclient_supported_distributions:
   - Ubuntu-14
+  - Ubuntu-16
   - CentOS-7
   - Fedora-22


### PR DESCRIPTION
Allow enrollment ipa client with or without DNS updates controlled by variable freeipaclient_enable_dns_updates

Allow run Ubuntu specific task for all Debians

Add Ubuntu 16.x to supported distributions.

Add nscd as required package for all supported platforms. This improve performance of client and decrease load of servers.

Change state of package to 'latest' - this will update to current version of packages.
