### PR TITLE
Deprecation Warning Fix - always_run to check_mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,7 +62,6 @@
     - enroll
     - freeipaclient
   register: freeipaclient_ipaconf
-  always_run: true
   stat:
     path: /etc/ipa/default.conf
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,6 +62,7 @@
     - enroll
     - freeipaclient
   register: freeipaclient_ipaconf
+  check_mode: no
   stat:
     path: /etc/ipa/default.conf
 


### PR DESCRIPTION
When running this role as is, you will encounter a deprecation warning:

```
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by
setting deprecation_warnings=False in ansible.cfg.
```

This PR just follows their directions and changes it to `check_mode: no` (although I wonder if we need this at all) to get rid of the deprecation warning.

If this gets merged, can you please cut a new release? We're using tagged releases.