### PR TITLE
Add support for RHEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This role allows to join clients to an ipa domain
 ## Requirements
 
 * CentOS 7
+* Red Hat Enterprise Linux 7
 * Fedora 24
 * Ubuntu Trusty
 * Ubuntu Xenial

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,4 @@
+freeipaclient_install_command: '/sbin/ipa-client-install'
+freeipaclient_packages:
+ - ipa-client
+ - dbus-python

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,4 +4,5 @@ freeipaclient_supported_distributions:
   - Ubuntu-14
   - Ubuntu-16
   - CentOS-7
+  - RedHat-7
   - Fedora-24


### PR DESCRIPTION
I used to use this role for CentOS 7 servers. Now I have to deploy RHEL 7 servers aswell. Actually, both systems are more or less the same.

I tested these changes with one of our vanilla RHEL 7 server and it worked like a charm.

It would be nice if you could add my changes to the upstream.