### PR TITLE
Default to using ansible_nodename as hostname if freeipaclient_hostname is not set

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,7 +74,7 @@
   when: not freeipaclient_ipaconf.stat.exists
   command: >
     {{ freeipaclient_install_command }}
-    {{'--hostname=' + freeipaclient_hostname  if freeipaclient_hostname is defined else ''}}
+    {{'--hostname=' + freeipaclient_hostname  if freeipaclient_hostname is defined else '--hostname=' + ansible_nodename }}
     --server={{ freeipaclient_server }}
     --domain={{ freeipaclient_domain }}
     --principal={{ freeipaclient_enroll_user }}


### PR DESCRIPTION
This change modifies the default hostname passed into the IPA client installer script. When using this playbook across many nodes at once, setting `freeipaclient_hostname` for each is repetitive. The current default (not passing the `--hostname` argument, aka using "uname -n") will fail if the host's hostname is set to "localhost" or if the non-qualified hostname is not unique. Using `ansible_nodename` will instead pass the fully-qualified domain name of each host to the IPA client installer script by default, which is substantially more likely to work out-of-the-box.

All tests pass too.