### PR TITLE
Add Ubuntu 18 to the supported list

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,6 +3,7 @@
 freeipaclient_supported_distributions:
   - Ubuntu-14
   - Ubuntu-16
+  - Ubuntu-18
   - CentOS-7
   - RedHat-7
   - Fedora-24


### PR DESCRIPTION
I tested on an Ubuntu 18 server & this role worked correctly once I added it to the supported list. I was able to login as my user from FreeIPA as expected.